### PR TITLE
Add winflexbison to all-deps

### DIFF
--- a/.github/workflows/all-deps.yml
+++ b/.github/workflows/all-deps.yml
@@ -86,6 +86,15 @@ jobs:
           path: /builddeps
           if_no_artifact_found: fail
 
+      - name: Download winflexbison
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: winflexbison.yml
+          workflow_conclusion: success
+          name: winflexbison-${{ vars.WINFLEXBISON_VERSION }}-win64
+          path: /builddeps
+          if_no_artifact_found: fail
+
       - name: Download zlib
         uses: dawidd6/action-download-artifact@v3
         with:

--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -27,11 +27,14 @@ jobs:
       - name: Install Meson and Flex etc
         run: |
           pip install meson ninja
-          choco install winflexbison3 pkgconfiglite
+          choco install pkgconfiglite
 
       - name: Configure
         run: |
           cd postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}
+          # so binaries can be found/run
+          $env:PATH="\postgresql-dev\bin\;\postgresql-dev\;$Env:PATH";
+
           meson setup --wipe --pkg-config-path=\builddeps\lib\pkgconfig -Dextra_include_dirs=\builddeps\include -Dextra_lib_dirs=\builddeps\lib -Duuid=ossp --prefix=\postgresql-dev build
 
       - name: Build

--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Download
         run: |
-          curl https://ftp.postgresql.org/pub/source/v${{ vars.POSTGRESQL_DEV_VERSION }}/postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}.tar.gz -o ./postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}.tar.gz
-          tar zxvf postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}.tar.gz
+          curl https://ftp.postgresql.org/pub/source/v${{ vars.POSTGRESQL_DEV_VERSION }}/postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}.tar.gz -o ./postgresql-dev-${{ vars.POSTGRESQL_DEV_VERSION }}.tar.gz
+          tar zxvf postgresql-dev-${{ vars.POSTGRESQL_DEV_VERSION }}.tar.gz
 
       - name: Install Meson and Flex etc
         run: |
@@ -84,4 +84,4 @@ jobs:
         with:
           if-no-files-found: error
           name: meson_log
-          path: D:\a\winpgbuild\winpgbuild\postgresql-17beta1\build\meson-logs\meson-log.txt
+          path: D:\a\winpgbuild\winpgbuild\postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}\build\meson-logs\meson-log.txt

--- a/.github/workflows/winflexbison.yml
+++ b/.github/workflows/winflexbison.yml
@@ -1,0 +1,20 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  build-winflexbison:
+    runs-on: windows-latest
+    steps:
+      - name: Download
+        run: |
+          curl -L -o winflexbison.zip "https://github.com/lexxmark/winflexbison/releases/download/v${{ vars.WINFLEXBISON_VERSION }}/win_flex_bison-${{ vars.WINFLEXBISON_VERSION }}.zip"
+          mkdir winflexbison
+          cd winflexbison
+          unzip ../winflexbison.zip
+
+      - name: Upload Binaries
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: winflexbison-${{ vars.WINFLEXBISON_VERSION }}-win64
+          path: winflexbison

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ components to build. These are listed below in square brackets.
 * lz4 [LZ4_VERSION]
 * openssl [OPENSSL_VERSION]
 * ossp-uuid [OSSP_UUID_VERSION].
+* winflexbison [WINFLEXBISON_VERSION]
 * zlib [ZLIB_VERSION]
 * zstd [ZSTD_VERSION]
 


### PR DESCRIPTION
Mostly because choco is so slow. But it's also a step towards reproducible builds.

Requires WINFLEXBISON_VERSION to be set in the repo variables.