### PR TITLE
postgresql-dev: Add dependencies to PATH

### DIFF
--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -19,6 +19,13 @@ jobs:
           path: /builddeps
           if_no_artifact_found: fail
 
+      - name: Add build deps to path
+        run: |
+          # so binaries and libraries can be found/run
+          echo "/builddeps/bin" >> $ENV:GITHUB_PATH
+          echo "/builddeps" >> $ENV:GITHUB_PATH
+          echo "/postgresql-dev/bin" >> $ENV:GITHUB_PATH
+
       - name: Download
         run: |
           curl https://ftp.postgresql.org/pub/source/v${{ vars.POSTGRESQL_DEV_VERSION }}/postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}.tar.gz -o ./postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}.tar.gz


### PR DESCRIPTION
We want to find binaries installed into /builddeps/bin. If we don't do so centrally, we have to do so in multiple steps (at least configure, build, test).