### PR TITLE
Meson ninja deps

### DIFF
--- a/.github/workflows/all-deps.yml
+++ b/.github/workflows/all-deps.yml
@@ -68,6 +68,24 @@ jobs:
           path: /builddeps
           if_no_artifact_found: fail
 
+      - name: Download meson
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: meson.yml
+          workflow_conclusion: success
+          name: meson-${{ vars.MESON_VERSION }}-win64
+          path: /builddeps
+          if_no_artifact_found: fail
+
+      - name: Download ninja
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: ninja.yml
+          workflow_conclusion: success
+          name: ninja-${{ vars.NINJA_VERSION }}-win64
+          path: /builddeps
+          if_no_artifact_found: fail
+
       - name: Download openssl
         uses: dawidd6/action-download-artifact@v3
         with:
@@ -103,6 +121,15 @@ jobs:
           name: zstd-${{ vars.ZSTD_VERSION }}-win64
           path: /builddeps
           if_no_artifact_found: fail
+
+      # github errors out due to too many files :(
+      - name: Remove docs
+        run: |
+          rm.exe -rf `
+              \builddeps\share\docs `
+              \builddeps\mesonbuild\docs `
+              "\builddeps\mesonbuild\test cases" `
+              \builddeps\html
 
       - name: Upload Binaries
         uses: actions/upload-artifact@v4

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -1,0 +1,28 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  build-meson:
+    runs-on: windows-latest
+    steps:
+      - name: Download
+        run: |
+          curl.exe -L -o meson.tar.gz https://github.com/mesonbuild/meson/releases/download/${{ vars.MESON_VERSION }}/meson-${{ vars.MESON_VERSION }}.tar.gz
+
+          mkdir -p /meson/mesonbuild
+          mkdir -p /meson/bin
+
+          tar -C /meson/mesonbuild --strip-components=1 -xvzf meson.tar.gz
+
+          echo "@python %~dp0/../mesonbuild/meson.py %*" | out-file -encoding ascii \meson\bin\meson.cmd;
+          \meson\bin\meson.cmd --help
+
+          $ENV:PATH="/meson/bin;$ENV:PATH"
+          meson --version || true
+
+      - name: Upload Binaries
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: meson-${{ vars.MESON_VERSION }}-win64
+          path: /meson

--- a/.github/workflows/ninja.yml
+++ b/.github/workflows/ninja.yml
@@ -1,0 +1,24 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  build-ninja:
+    runs-on: windows-latest
+    steps:
+      - name: Download
+        run: |
+          curl -L -o ninja.zip https://github.com/ninja-build/ninja/releases/download/v${{ vars.NINJA_VERSION }}/ninja-win.zip
+          mkdir /ninja/bin
+
+          unzip ninja.zip
+          cp ninja.exe /ninja/bin
+          ls /ninja/bin
+          $ENV:PATH="/ninja/bin;$ENV:PATH"
+          ninja --version || true
+
+      - name: Upload Binaries
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: ninja-${{ vars.NINJA_VERSION }}-win64
+          path: /ninja

--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -33,7 +33,6 @@ jobs:
 
       - name: Install Meson and Flex etc
         run: |
-          pip install meson ninja
           choco install winflexbison3 pkgconfiglite
 
       - name: Configure

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ components to build. These are listed below in square brackets.
 * libxml2 [LIBXML2_VERSION]
 * libxslt [LIBXSLT_VERSION]
 * lz4 [LZ4_VERSION]
+* meson [MESON_VERSION]
+* ninja [NINJA_VERSION]
 * openssl [OPENSSL_VERSION]
 * ossp-uuid [OSSP_UUID_VERSION].
 * zlib [ZLIB_VERSION]


### PR DESCRIPTION
Mostly to avoid the need for doing so during every run. I found that installing via pip and choco was hurting my iteration speed.  But it also seems required for reproducible builds.

This requires https://github.com/dpage/winpgbuild/pull/7 to be merged first (I've now included a merge commit for that PR, but this should be rebased before merging). Otherwise the installed meson/ninja won't be found.