### PR TITLE
postgresql-dev: Use unix sockets

### DIFF
--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Test
         run: |
           cd postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}\build
+
+          # use unix socket to prevent port conflicts
+          $env:PG_TEST_USE_UNIX_SOCKETS = 1;
+          # otherwise pg_regress insists on creating the directory and does it
+          # in a non-existing place, this needs to be fixed :(
+          mkdir d:/sockets
+          $env:PG_REGRESS_SOCK_DIR = "d:/sockets/"
+
           meson test
 
       - name: Install


### PR DESCRIPTION
This prevents spurious failures due to port conflicts.

Branches not using meson don't currently need this, as they does not run any tests concurrently.