### PR TITLE
postgresql-dev: Improve meson setup 

### DIFF
--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -38,8 +38,6 @@ jobs:
       - name: Configure
         run: |
           cd postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}
-          # so binaries can be found/run
-          $env:PATH="\postgresql-dev\bin\;\postgresql-dev\;$Env:PATH";
 
           meson setup --wipe --pkg-config-path=\builddeps\lib\pkgconfig -Dextra_include_dirs=\builddeps\include -Dextra_lib_dirs=\builddeps\lib -Duuid=ossp --prefix=\postgresql-dev build
 

--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -39,7 +39,25 @@ jobs:
         run: |
           cd postgresql-${{ vars.POSTGRESQL_DEV_VERSION }}
 
-          meson setup --wipe --pkg-config-path=\builddeps\lib\pkgconfig -Dextra_include_dirs=\builddeps\include -Dextra_lib_dirs=\builddeps\lib -Duuid=ossp --prefix=\postgresql-dev build
+          # don't use \path style paths for library search, link.exe ends up
+          # interpreting paths like that as flags!
+          $deps = resolve-path /builddeps
+
+          # can't enable some extra tests
+          # - libpq_encryption -> fails for unknown reasons
+          # - kerberos -> test not yet supported on windows
+          # - load_balance -> would need to set up hostnames
+          meson setup `
+              --prefix=\postgresql-dev `
+              "--cmake-prefix-path=${deps}" `
+              "--pkg-config-path=${deps}\lib\pkgconfig" `
+              "-Dextra_include_dirs=${deps}\include" `
+              "-Dextra_lib_dirs=${deps}\lib,${deps}\lib\amd64" `
+              "-DPG_TEST_EXTRA=ldap ssl" `
+              -Duuid=ossp `
+              -Db_pch=true `
+              -Dbuildtype=debugoptimized `
+              build
 
       - name: Build
         run: |


### PR DESCRIPTION
1) split across lines to make it easier to read
2) specify cmake prefix, to find more dependencies
3) use precompiled headers for a substantially faster build
4) generate debug information
5) add lib\amd64 to library path, otherwise kerberos can't be found
6) enable some additional tests

If you'd prefer, I can split this across several PRs.