### PR TITLE
postgresql: msbuild flags for faster build

### DIFF
--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -9,6 +9,16 @@ jobs:
         version: ${{ fromJSON(vars.POSTGRESQL_VERSIONS) }}
 
     runs-on: windows-latest
+
+    # -m enables parallelism
+    # verbosity:minimal + Summary reduce verbosity, while keeping a summary of
+    #   errors/warnings
+    # ForceNoAlign prevents msbuild from introducing line-breaks for long lines
+    # disable file tracker, we're never going to rebuild, and it slows down the
+    #   build
+    env:
+      MSBFLAGS: -m -verbosity:minimal "-consoleLoggerParameters:Summary;ForceNoAlign" /p:TrackFileAccess=false -nologo
+
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
 


### PR DESCRIPTION
Cribbed from postgres
https://github.com/postgres/postgres/blob/468b2367d2fe29fe1a53bcba408b472dc8f5051b/.cirrus.tasks.yml#L347-L353

Here's an [example run](https://github.com/anarazel/winpgbuild/actions/runs/9864312450) comparing using the flags and not: 
- no flags: 4m19s
- flags: 3m16s

(the failure is just because both produce the same source tarball)