### PR TITLE
postgresql: Add dependencies to PATH

### DIFF
--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -53,6 +53,13 @@ jobs:
           copy \builddeps\bin\libzstd.dll \postgresql\bin\
           copy \builddeps\bin\zlib1.dll \postgresql\bin\
 
+      - name: Add build deps to path
+        run: |
+          # so binaries and libraries can be found/run
+          echo "/builddeps/bin" >> $ENV:GITHUB_PATH
+          echo "/builddeps" >> $ENV:GITHUB_PATH
+          echo "/postgresql/bin" >> $ENV:GITHUB_PATH
+
       - name: Download
         run: |
           curl https://ftp.postgresql.org/pub/source/v${{ matrix.version }}/postgresql-${{ matrix.version }}.tar.gz -o ./postgresql-${{ matrix.version }}.tar.gz
@@ -88,8 +95,6 @@ jobs:
           >> config.pl echo };
           >> config.pl echo.
           >> config.pl echo 1;
-
-          >> buildenv.pl echo $ENV{PATH} = "\\builddeps\\bin;\\builddeps\\bin64;$ENV{PATH}";
         shell: cmd
 
       - name: Build


### PR DESCRIPTION
Without this bison and flex are not found, because msbuild is invoked directly. That could be fixed, but it seems easier to just configure PATH globally.

An example successful run with it:
https://github.com/anarazel/winpgbuild/actions/runs/9879894664/job/27289230134

Note that in contrast to runs without it, there are no warnings about flex/bison not being available:
https://github.com/dpage/winpgbuild/actions/runs/9855807053/job/27211463701#step:6:226