### PR TITLE
Optimize build paths for Meson 1.9.1+ to avoid Windows PATH limit

### DIFF
--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -85,9 +85,31 @@ jobs:
           cd postgresql-${{ env.POSTGRESQL-DEV_VERSION }}
           git archive --format=tar.gz -o ../postgresql-dev-${{ env.POSTGRESQL-DEV_VERSION }}.tar.gz --prefix=postgresql-dev-${{ env.POSTGRESQL-DEV_VERSION }}/ ${{ env.POSTGRESQL-DEV_VERSION }}
 
+      # Optimize path length for Meson 1.9.1+ to avoid Windows 32KB PATH limit
+      # Meson adds all build output directories to PATH during tests,
+      # which can exceed the limit with 200+ test directories.
+      # Moving to \s\pg (short) and using SUBST saves ~50 chars per path
+      # = ~10KB total PATH reduction with 200 paths
+      - name: Setup Short Paths
+        run: |
+          # Move to short root path
+          New-Item -ItemType Directory -Force -Path \s
+          Move-Item postgresql-${{ env.POSTGRESQL-DEV_VERSION }} \s\pg
+
+          # Create virtual drive mapping to further shorten paths
+          # P:\b is only 4 chars vs ~55 chars for full GitHub Actions path
+          subst P: \s\pg
+
+          # Verify the mapping works
+          Write-Host "SUBST drive created:"
+          subst
+          Write-Host "`nDirectory contents:"
+          Get-ChildItem P:\ | Select-Object -First 5
+
       - name: Configure
         run: |
-          cd postgresql-${{ env.POSTGRESQL-DEV_VERSION }}
+          # Use short SUBST path (P:) instead of long GitHub Actions path
+          cd P:\
 
           # don't use \path style paths for library search, link.exe ends up
           # interpreting paths like that as flags!
@@ -108,16 +130,16 @@ jobs:
               -Db_pch=true `
               -Dgssapi=disabled `
               -Dbuildtype=debugoptimized `
-              build
+              b
 
       - name: Build
         run: |
-          cd postgresql-${{ env.POSTGRESQL-DEV_VERSION }}\build
+          cd P:\b
           ninja -j 1
 
       - name: Test
         run: |
-          cd postgresql-${{ env.POSTGRESQL-DEV_VERSION }}\build
+          cd P:\b
 
           # use unix socket to prevent port conflicts
           $env:PG_TEST_USE_UNIX_SOCKETS = 1;
@@ -134,15 +156,15 @@ jobs:
         with:
           name: test_logs
           path: |
-            postgresql-${{ env.POSTGRESQL-DEV_VERSION }}\build\testrun\**\*.log
-            postgresql-${{ env.POSTGRESQL-DEV_VERSION }}\build\testrun\**\regress_log_*
-            postgresql-${{ env.POSTGRESQL-DEV_VERSION }}\build\testrun\**\*.diffs
-            postgresql-${{ env.POSTGRESQL-DEV_VERSION }}\build\testrun\**\*.out
-            postgresql-${{ env.POSTGRESQL-DEV_VERSION }}\build\meson-logs\testlog.txt
+            \s\pg\b\testrun\**\*.log
+            \s\pg\b\testrun\**\regress_log_*
+            \s\pg\b\testrun\**\*.diffs
+            \s\pg\b\testrun\**\*.out
+            \s\pg\b\meson-logs\testlog.txt
 
       - name: Install
         run: |
-          cd postgresql-${{ env.POSTGRESQL-DEV_VERSION }}\build
+          cd P:\b
 
           meson install --quiet
 
@@ -166,7 +188,7 @@ jobs:
         with:
           if-no-files-found: error
           name: meson_log
-          path: postgresql-${{ env.POSTGRESQL-DEV_VERSION }}\build\meson-logs\meson-log.txt
+          path: \s\pg\b\meson-logs\meson-log.txt
 
       - name: Package Release Assets
         shell: pwsh

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -89,6 +89,28 @@ jobs:
           curl https://ftp.postgresql.org/pub/source/v${{ matrix.version }}/postgresql-${{ matrix.version }}.tar.gz -o ./postgresql-${{ matrix.version }}.tar.gz
           tar zxvf postgresql-${{ matrix.version }}.tar.gz
 
+      # Optimize path length for Meson 1.9.1+ to avoid Windows 32KB PATH limit
+      # Meson adds all build output directories to PATH during tests,
+      # which can exceed the limit with 200+ test directories.
+      # Moving to \s\pg (short) and using SUBST saves ~50 chars per path
+      # = ~10KB total PATH reduction with 200 paths
+      - name: Setup Short Paths (meson)
+        run: |
+          # Move to short root path
+          New-Item -ItemType Directory -Force -Path \s
+          Move-Item postgresql-${{ matrix.version }} \s\pg
+
+          # Create virtual drive mapping to further shorten paths
+          # P:\b is only 4 chars vs ~55 chars for full GitHub Actions path
+          subst P: \s\pg
+
+          # Verify the mapping works
+          Write-Host "SUBST drive created:"
+          subst
+          Write-Host "`nDirectory contents:"
+          Get-ChildItem P:\ | Select-Object -First 5
+        if: ${{ fromJson(matrix.version) >= 17.0 }}
+
       - name: Configure (msvc)
         run: |
           cd postgresql-${{ matrix.version }}\src\tools\msvc
@@ -124,7 +146,8 @@ jobs:
 
       - name: Configure (meson)
         run: |
-          cd postgresql-${{ matrix.version }}
+          # Use short SUBST path (P:) instead of long GitHub Actions path
+          cd P:\
 
           # don't use \path style paths for library search, link.exe ends up
           # interpreting paths like that as flags!
@@ -145,7 +168,7 @@ jobs:
               -Db_pch=true `
               -Dgssapi=disabled `
               -Dbuildtype=debugoptimized `
-              build
+              b
         if: ${{ fromJson(matrix.version) >= 17.0 }}
 
       - name: Build (msvc)
@@ -157,7 +180,7 @@ jobs:
 
       - name: Build (meson)
         run: |
-          cd postgresql-${{ matrix.version }}\build
+          cd P:\b
           ninja -j 1
         if: ${{ fromJson(matrix.version) >= 17.0 }}
 
@@ -170,7 +193,7 @@ jobs:
 
       - name: Test (meson)
         run: |
-          cd postgresql-${{ matrix.version }}\build
+          cd P:\b
 
           # use unix socket to prevent port conflicts
           $env:PG_TEST_USE_UNIX_SOCKETS = 1;
@@ -188,11 +211,11 @@ jobs:
           if-no-files-found: ignore
           name: postgresql-${{ matrix.version }}-test-logs
           path: |
-            postgresql-${{ matrix.version }}\build\testrun\**\*.log
-            postgresql-${{ matrix.version }}\build\testrun\**\regress_log_*
-            postgresql-${{ matrix.version }}\build\testrun\**\*.diffs
-            postgresql-${{ matrix.version }}\build\testrun\**\*.out
-            postgresql-${{ matrix.version }}\build\meson-logs\testlog.txt
+            \s\pg\b\testrun\**\*.log
+            \s\pg\b\testrun\**\regress_log_*
+            \s\pg\b\testrun\**\*.diffs
+            \s\pg\b\testrun\**\*.out
+            \s\pg\b\meson-logs\testlog.txt
         if: always()
 
       - name: Install (msvc)
@@ -205,7 +228,7 @@ jobs:
 
       - name: Install (meson)
         run: |
-          cd postgresql-${{ matrix.version }}\build
+          cd P:\b
 
           meson install --quiet
         if: ${{ fromJson(matrix.version) >= 17.0 }}
@@ -239,7 +262,7 @@ jobs:
         with:
           if-no-files-found: ignore
           name: postgresql-${{ matrix.version }}-meson-log
-          path: postgresql-${{ matrix.version }}\build\meson-logs\meson-log.txt
+          path: \s\pg\b\meson-logs\meson-log.txt
         if: always()
 
       - name: Package Release Assets

--- a/manifest.json
+++ b/manifest.json
@@ -74,7 +74,7 @@
       },
       {
         "name": "meson",
-        "version": "1.8.2",
+        "version": "1.9.1",
         "source": "https://mesonbuild.com",
         "licence": "https://github.com/mesonbuild/meson/blob/master/COPYING"
       },


### PR DESCRIPTION
Meson 1.9.1+ automatically adds all build output directories to PATH during test execution, which can exceed Windows' 32KB environment variable limit with PostgreSQL's 200+ test directories.

This commit implements a path optimization strategy:

1. **Shorten base path**: Move extracted source from long GitHub Actions path to \s\pg (saves ~30 chars)

2. **Shorten build directory**: Use 'b' instead of 'build' (saves 4 chars)

3. **SUBST virtual drive**: Map P: -> \s\pg to minimize path length in Meson's internal PATH construction (P:\b vs full path)

**Total savings**: ~50 chars per directory × 200+ directories = ~10KB This brings the PATH from ~40KB down to ~30KB, staying under the 32KB limit.

**Why previous workarounds failed**:
Setting PATH at the workflow level cannot override Meson's internal PATH construction. Meson's test harness builds its own environment when spawning test processes, adding all build directories regardless of the workflow environment.

**Why this works**:
By shortening the actual filesystem paths that Meson uses to construct its PATH, we reduce the length before Meson processes them.

Changes:
- .github/workflows/postgresql.yml: Add path optimization for PG 17+
- .github/workflows/postgresql-dev.yml: Add path optimization for dev builds
- manifest.json: Update Meson version from 1.8.2 to 1.9.1

Related commits: c044828, 005d0a9-43e87a9 (previous unsuccessful attempts)