### PR TITLE
Fix builddeps path resolution in Configure step

### DIFF
--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -108,12 +108,13 @@ jobs:
 
       - name: Configure
         run: |
-          # Use short SUBST path (P:) instead of long GitHub Actions path
-          cd P:\
-
           # don't use \path style paths for library search, link.exe ends up
           # interpreting paths like that as flags!
+          # Resolve this BEFORE changing to P:\ drive
           $deps = resolve-path /builddeps
+
+          # Use short SUBST path (P:) instead of long GitHub Actions path
+          cd P:\
 
           # can't enable some extra tests
           # - libpq_encryption -> fails for unknown reasons

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -146,12 +146,13 @@ jobs:
 
       - name: Configure (meson)
         run: |
-          # Use short SUBST path (P:) instead of long GitHub Actions path
-          cd P:\
-
           # don't use \path style paths for library search, link.exe ends up
           # interpreting paths like that as flags!
+          # Resolve this BEFORE changing to P:\ drive
           $deps = resolve-path /builddeps
+
+          # Use short SUBST path (P:) instead of long GitHub Actions path
+          cd P:\
 
           # can't enable some extra tests
           # - libpq_encryption -> fails for unknown reasons


### PR DESCRIPTION
The resolve-path command must be executed BEFORE changing to the P:\ drive, otherwise it tries to find P:\builddeps instead of D:\builddeps.

This fixes the error:
Cannot find path 'P:\builddeps' because it does not exist.