### PR TITLE
Add verification steps for SUBST drive mapping

### DIFF
--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -92,6 +92,14 @@ jobs:
           New-Item -ItemType Directory -Force -Path \s
           Move-Item postgresql-${{ env.POSTGRESQL-DEV_VERSION }} \s\pg
 
+          # Verify the move succeeded
+          if (-not (Test-Path \s\pg)) {
+            Write-Error "Failed to move postgresql-${{ env.POSTGRESQL-DEV_VERSION }} to \s\pg"
+            exit 1
+          }
+          Write-Host "PostgreSQL source moved to \s\pg"
+          Get-ChildItem \s\pg | Select-Object -First 5
+
           # Resolve builddeps before creating SUBST drive
           $deps = resolve-path /builddeps
 
@@ -99,11 +107,24 @@ jobs:
           # This mapping only persists for this PowerShell session
           subst P: \s\pg
 
-          # Verify mapping
-          Write-Host "SUBST drive P: created, mapping to \s\pg"
+          # Verify SUBST succeeded
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "SUBST command failed with exit code $LASTEXITCODE"
+            exit 1
+          }
+
+          # Verify P:\ is accessible
+          if (-not (Test-Path P:\)) {
+            Write-Error "P:\ drive is not accessible after SUBST"
+            subst
+            exit 1
+          }
+
+          Write-Host "SUBST drive P: created successfully"
+          Get-ChildItem P:\ | Select-Object -First 5
 
           # Change to the virtual drive
-          cd P:\
+          Set-Location P:\
 
           # can't enable some extra tests
           # - libpq_encryption -> fails for unknown reasons

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -129,6 +129,14 @@ jobs:
           New-Item -ItemType Directory -Force -Path \s
           Move-Item postgresql-${{ matrix.version }} \s\pg
 
+          # Verify the move succeeded
+          if (-not (Test-Path \s\pg)) {
+            Write-Error "Failed to move postgresql-${{ matrix.version }} to \s\pg"
+            exit 1
+          }
+          Write-Host "PostgreSQL source moved to \s\pg"
+          Get-ChildItem \s\pg | Select-Object -First 5
+
           # Resolve builddeps before creating SUBST drive
           $deps = resolve-path /builddeps
 
@@ -136,11 +144,24 @@ jobs:
           # This mapping only persists for this PowerShell session
           subst P: \s\pg
 
-          # Verify mapping
-          Write-Host "SUBST drive P: created, mapping to \s\pg"
+          # Verify SUBST succeeded
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "SUBST command failed with exit code $LASTEXITCODE"
+            exit 1
+          }
+
+          # Verify P:\ is accessible
+          if (-not (Test-Path P:\)) {
+            Write-Error "P:\ drive is not accessible after SUBST"
+            subst
+            exit 1
+          }
+
+          Write-Host "SUBST drive P: created successfully"
+          Get-ChildItem P:\ | Select-Object -First 5
 
           # Change to the virtual drive
-          cd P:\
+          Set-Location P:\
 
           # can't enable some extra tests
           # - libpq_encryption -> fails for unknown reasons


### PR DESCRIPTION
Added diagnostic output to identify why SUBST drive mapping fails:
- Verify directory move succeeded before creating SUBST
- Check SUBST command exit code
- Verify P:\ drive is accessible before attempting cd
- Show directory contents at each step for debugging
- Use Set-Location instead of cd for more reliable directory changes

This will help diagnose whether the issue is with:
1. The Move-Item operation
2. The SUBST command itself
3. The drive accessibility after SUBST