### PR TITLE
Enable GSSAPI (MIT Kerberos) for the PG18 and dev builds

### DIFF
--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -52,6 +52,18 @@ jobs:
           copy \builddeps\bin\libzstd.dll \postgresql\bin\
           copy \builddeps\bin\zlib1.dll \postgresql\bin\
 
+      # GSSAPI (MIT Kerberos) is enabled for the dev (master) build, so bundle
+      # the krb5 runtime DLLs that libpq's gssapi support links against.
+      - name: Install GSSAPI runtime dependencies
+        run: |
+          copy \builddeps\bin\gssapi64.dll \postgresql\bin\
+          copy \builddeps\bin\krb5_64.dll \postgresql\bin\
+          copy \builddeps\bin\comerr64.dll \postgresql\bin\
+          copy \builddeps\bin\k5sprt64.dll \postgresql\bin\
+          copy \builddeps\bin\xpprof64.dll \postgresql\bin\
+          copy \builddeps\bin\krbcc64.dll \postgresql\bin\
+        shell: cmd
+
       - name: Add build deps to path
         run: |
           # so binaries and libraries can be found/run
@@ -110,7 +122,7 @@ jobs:
               "-DPG_TEST_EXTRA=ldap ssl" `
               -Duuid=ossp `
               -Db_pch=true `
-              -Dgssapi=disabled `
+              -Dgssapi=enabled `
               -Dbuildtype=debugoptimized `
               b
 

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -63,6 +63,20 @@ jobs:
           copy \builddeps\bin\libzstd.dll \postgresql\bin\
           copy \builddeps\bin\zlib1.dll \postgresql\bin\
 
+      # GSSAPI (MIT Kerberos) is only enabled for PG18+ (see the meson
+      # Configure step), so only those builds need the krb5 runtime DLLs that
+      # libpq's gssapi support links against.
+      - name: Install GSSAPI runtime dependencies
+        run: |
+          copy \builddeps\bin\gssapi64.dll \postgresql\bin\
+          copy \builddeps\bin\krb5_64.dll \postgresql\bin\
+          copy \builddeps\bin\comerr64.dll \postgresql\bin\
+          copy \builddeps\bin\k5sprt64.dll \postgresql\bin\
+          copy \builddeps\bin\xpprof64.dll \postgresql\bin\
+          copy \builddeps\bin\krbcc64.dll \postgresql\bin\
+        shell: cmd
+        if: ${{ fromJson(matrix.version) >= 18.0 }}
+
       - name: Add build deps to path
         run: |
           # so binaries and libraries can be found/run
@@ -134,6 +148,15 @@ jobs:
           # Change to source directory
           cd \s\pg
 
+          # GSSAPI (MIT Kerberos) can only be enabled on PG18+. The Windows
+          # build of libpq with both OpenSSL and GSSAPI enabled fails to
+          # compile on older branches because <wincrypt.h> #defines X509_NAME,
+          # clobbering OpenSSL's typedef. That was fixed upstream by the commit
+          # adding src/include/libpq/pg-gssapi.h, which is present in PG18 and
+          # master but was not back-patched to 17 or earlier.
+          $pgMajor = [int]( '${{ matrix.version }}'.Split('.')[0] )
+          $gssapi = if ($pgMajor -ge 18) { 'enabled' } else { 'disabled' }
+
           # can't enable some extra tests
           # - libpq_encryption -> fails for unknown reasons
           # - kerberos -> test not yet supported on windows
@@ -147,7 +170,7 @@ jobs:
               "-DPG_TEST_EXTRA=ldap ssl" `
               -Duuid=ossp `
               -Db_pch=true `
-              -Dgssapi=disabled `
+              -Dgssapi=$gssapi `
               -Dbuildtype=debugoptimized `
               b
         if: ${{ fromJson(matrix.version) >= 17.0 }}


### PR DESCRIPTION
## Summary

The Windows libpq is currently built with `-Dgssapi=disabled`, so `gssencmode`
is unavailable and Kerberos/GSSAPI authentication to remote servers fails with:

```
gssencmode value "require" invalid when GSSAPI support is not compiled in
```

(reported against pgAdmin as pgadmin-org/pgadmin4#9707).

GSSAPI was disabled because building libpq with **both** OpenSSL and GSSAPI on
Windows failed to compile: `<wincrypt.h>` `#define`s `X509_NAME`, clobbering
OpenSSL's `typedef X509_NAME` (50+ syntax errors in `x509v3.h`). That was the
subject of [this pgsql-hackers thread](https://www.postgresql.org/message-id/flat/CA%2BOCxoxwsgi8QdzN8A0OPGuGfu_1vEW3ufVBnbwd3gfawVpsXw%40mail.gmail.com)
and was fixed upstream by the commit adding `src/include/libpq/pg-gssapi.h`
(centralised `#undef X509_NAME`). That fix is present in **PG18 and master**
but was **not back-patched** to 17 or earlier — so GSSAPI can only be enabled
for 18+.

The supporting pieces are already in place: `krb5.yml` builds MIT Kerberos with
GSSAPI and bundles it (libs under `lib/amd64`, headers, and the `krb5-gssapi.pc`
that PostgreSQL's meson build uses to detect it). So this change is small.

## Changes

**`postgresql.yml`** (version matrix)
- Compute the GSSAPI option from the major version: `enabled` for PG18+, else
  `disabled`. PG17 and earlier are unchanged.
- Add an `Install GSSAPI runtime dependencies` step (gated on `>= 18.0`) that
  copies the krb5 runtime DLLs into `postgresql/bin`.

**`postgresql-dev.yml`** (master)
- Enable `-Dgssapi=enabled` unconditionally.
- Bundle the same krb5 runtime DLLs.

Runtime DLLs bundled: `gssapi64`, `krb5_64`, `comerr64`, `k5sprt64`,
`xpprof64`, `krbcc64`.

## Notes / things to verify on a real run
- The meson detection relies on `dependency('krb5-gssapi')` resolving via the
  bundled `krb5-gssapi.pc` (already on `--pkg-config-path`); the import libs
  (`lib/amd64`) and headers are already on `extra_lib_dirs`/`extra_include_dirs`.
- The runtime DLL set is the core GSSAPI client chain; if `psql`/libpq reports
  a missing DLL at load time on a clean machine, we may need to add another
  krb5 DLL (e.g. the `plugins/preauth` directory).
- PG17/16/15/14 deliberately remain `-Dgssapi=disabled` (no upstream fix).