### PR TITLE
Restore standalone dispatch of the PostgreSQL build workflows

### DIFF
--- a/.github/workflows/postgresql-dev.yml
+++ b/.github/workflows/postgresql-dev.yml
@@ -24,11 +24,36 @@ jobs:
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
 
+      # When run via build-all (workflow_call), the all-deps-win64 artifact is
+      # produced by the bundle-deps job earlier in the same run, so this
+      # same-run lookup succeeds. continue-on-error lets a standalone dispatch
+      # (where no such artifact exists) fall through to the release fallback
+      # below instead of failing the job.
       - name: Download dependencies
+        id: download-deps
         uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           name: all-deps-win64
           path: /builddeps
+
+      # Standalone dispatch has no same-run artifact; pull the dependencies
+      # from the dependencies-latest release published by bundle-deps. The
+      # release archive has a top-level builddeps/ directory, so extracting to
+      # the filesystem root reproduces the \builddeps layout. Skipped on
+      # build-all runs, where the step above already succeeded.
+      - name: Download dependencies (release fallback)
+        if: steps.download-deps.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download dependencies-latest `
+              --repo ${{ github.repository }} `
+              --pattern postgresql-dependencies-latest.zip `
+              --dir $env:RUNNER_TEMP
+          Expand-Archive `
+              -Path $env:RUNNER_TEMP\postgresql-dependencies-latest.zip `
+              -DestinationPath \ -Force
 
       # Copy libraries requires at runtime to installation directory.
       #

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -35,11 +35,36 @@ jobs:
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
 
+      # When run via build-all (workflow_call), the all-deps-win64 artifact is
+      # produced by the bundle-deps job earlier in the same run, so this
+      # same-run lookup succeeds. continue-on-error lets a standalone dispatch
+      # (where no such artifact exists) fall through to the release fallback
+      # below instead of failing the job.
       - name: Download dependencies
+        id: download-deps
         uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           name: all-deps-win64
           path: /builddeps
+
+      # Standalone dispatch has no same-run artifact; pull the dependencies
+      # from the dependencies-latest release published by bundle-deps. The
+      # release archive has a top-level builddeps/ directory, so extracting to
+      # the filesystem root reproduces the \builddeps layout. Skipped on
+      # build-all runs, where the step above already succeeded.
+      - name: Download dependencies (release fallback)
+        if: steps.download-deps.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download dependencies-latest `
+              --repo ${{ github.repository }} `
+              --pattern postgresql-dependencies-latest.zip `
+              --dir $env:RUNNER_TEMP
+          Expand-Archive `
+              -Path $env:RUNNER_TEMP\postgresql-dependencies-latest.zip `
+              -DestinationPath \ -Force
 
       # Copy libraries requires at runtime to installation directory.
       #


### PR DESCRIPTION
## Summary

Switching dependency downloads to `actions/download-artifact@v7` (commit
`fde0dac`) made the `all-deps-win64` lookup a **current-run** lookup. That's
correct for **build-all** (`workflow_call`), where `bundle-deps` produces the
artifact in the same run — but it broke dispatching **Build PostgreSQL** /
**Build PostgreSQL (Dev)** on their own. Standalone, there is no such artifact
in the run, so the job fails immediately at *Download dependencies*:

```
##[error]Unable to download artifact(s): Artifact not found for name: all-deps-win64
```

`fde0dac` called this out as a deliberate trade-off ("Build-all is now the
canonical path"), but standalone leaf/PG dispatch is genuinely useful — e.g.
to test a single change quickly without the full ~hour matrix.

## Fix

- Mark the same-run `download-artifact` step `continue-on-error` and give it an `id`.
- Add a fallback step (`if: steps.download-deps.outcome == 'failure'`) that
  pulls the deps from the `dependencies-latest` **release** published by
  `bundle-deps` and extracts them. The release archive has a top-level
  `builddeps/` directory, so extracting to the filesystem root reproduces the
  exact `\builddeps` layout the artifact download would have produced (verified
  against the current release asset).

## Why build-all stays correct

`postgresql` / `postgresql-dev` have `needs: bundle-deps`, so they only run
when `bundle-deps` succeeded — meaning the same-run `all-deps-win64` artifact
is always present in a build-all run and the primary download succeeds. The
fallback is therefore skipped on build-all, preserving the fresh same-run
artifact (and the SPDX manifest correctness `fde0dac` was fixing). It only
fires on standalone dispatch.

## Scope

Limited to the two PostgreSQL workflows (the ones most useful to run on their
own). The same pattern could be applied to the leaf workflows / `bundle-deps`
later if standalone dispatch of those is wanted.

## Testing

Best validated by dispatching **Build PostgreSQL** on this branch standalone
and confirming the fallback fetches `dependencies-latest` and the build
proceeds. (Refs #30, which introduced the trade-off.)