### PR TITLE
Fix unexpanded $gssapi in the meson configure args

### DIFF
--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -195,7 +195,7 @@ jobs:
               "-DPG_TEST_EXTRA=ldap ssl" `
               -Duuid=ossp `
               -Db_pch=true `
-              -Dgssapi=$gssapi `
+              "-Dgssapi=$gssapi" `
               -Dbuildtype=debugoptimized `
               b
         if: ${{ fromJson(matrix.version) >= 17.0 }}


### PR DESCRIPTION
## Summary

PR #43 computes the GSSAPI build option into a PowerShell `$gssapi` variable
(enabled for PG18+, disabled otherwise) and passed it to meson as an
**unquoted** argument: `-Dgssapi=$gssapi`. PowerShell did not expand the
variable in that bare, dash-prefixed token, so meson received the literal
string and the PG18 (and PG17) configure failed:

```
meson.build:9:0: ERROR: Value "$gssapi" (of type "string") for option "gssapi"
is not one of the choices. Possible choices are: "enabled", "disabled", "auto".
```

Every other variable-bearing meson argument in that step is double-quoted and
expands correctly. Quoting `"-Dgssapi=$gssapi"` to match fixes it.

The **dev/master** build was unaffected (it hardcodes `-Dgssapi=enabled`) and
in the validation run it configured, compiled, and passed core+ecpg tests with
GSSAPI enabled — confirming GSSAPI support itself works; this was purely a
shell-quoting bug in the matrix workflow.

## Already validated (runs 27286517612 / 27286528467 on main)
- #44 release fallback fired and supplied deps in standalone dispatch
- `Install GSSAPI runtime dependencies` bundled the krb5 DLLs
- master: GSSAPI configure + build + tests green
- PG18.4: failed only at this meson arg → fixed here